### PR TITLE
Consistent behaviour for template sync

### DIFF
--- a/src/commands/templates/sync.ts
+++ b/src/commands/templates/sync.ts
@@ -1,7 +1,7 @@
 import * as ospath from 'path';
 import * as fs from 'fs';
 import { epilogue } from '../../helpers/util';
-import { readTemplateFiles, readTemplateJson } from './util/readTemplateFiles';
+import { readTemplateFiles, readTemplateFolder, readTemplateJson } from './util/readTemplateFiles';
 import { buildTemplates } from './util/buildTemplates';
 import { TemplateService } from './util/templateService';
 import { uploadTemplate } from './util/uploadTemplate';
@@ -15,39 +15,44 @@ export const builder = (yargs: any) => epilogue(yargs).options({
     describe: 'Directory containing the templates which need to be synced',
     type: 'string',
   },
-  file: {
+  template: {
     demandOption: false,
     describe: 'Template file to sync',
     type: 'string',
   },
-}).check(({ path, file }) => {
-  if (file && (!fs.existsSync(ospath.join(process.cwd(), file)) || !fs.statSync(ospath.join(process.cwd(), file)).isFile())) {
+}).check(({ path, template }) => {
+  if (template && !fs.existsSync(ospath.join(process.cwd(), template))) {
     throw new Error('please provide a valid file path for your template');
   }
   if (path && (!fs.existsSync(ospath.join(process.cwd(), path)) || fs.statSync(ospath.join(process.cwd(), path)).isFile())) {
-    console.log(ospath.join(process.cwd(), path));
     throw new Error('please provide a valid directory path for your code');
   }
 
-  if ((file && path) || (!file && !path)) {
-    throw new Error('Either path or file must be specified (but not both at the same time)');
+  if ((template && path) || (!template && !path)) {
+    throw new Error('Either path or template must be specified (but not both at the same time)');
   }
   return true;
 });
 
-export const handler = async ({ sdk, path, file }) => {
+export const handler = async ({ sdk, path, template }) => {
   const service: TemplateService = new TemplateService(sdk);
   if (path) {
     await syncTargetDir(service, ospath.resolve(path || '.'));
-  } else if (file.endsWith('.json')) {
-    const templateName = removeFileNameExtension(ospath.basename(file));
-    const template = await readTemplateJson(file);
-    await buildAndUploadTemplates(service, { [templateName]: template });
+    return;
   }
+
+  let templ = null;
+  const templateName = removeFileNameExtension(ospath.basename(template));
+  if (fs.statSync(ospath.join(process.cwd(), template)).isFile()) {
+    /* In case a template file was provided */
+    templ = await readTemplateJson(template);
+  } else {
+    templ = await readTemplateFolder(template);
+  }
+  await buildAndUploadTemplates(service, { [templateName]: templ });
 };
 
 async function buildAndUploadTemplates(service: TemplateService, templateObject: any) {
-  console.log(templateObject);
   const templates = await buildTemplates(service, templateObject);
   for (const template of templates) {
     await uploadTemplate(service, template);

--- a/src/commands/templates/util/readTemplateFiles.ts
+++ b/src/commands/templates/util/readTemplateFiles.ts
@@ -24,7 +24,7 @@ export async function readTemplateJson(fileName: string) {
   return readJsonFile(fileName);
 }
 
-async function readTemplateFolder(subFolder: string) {
+export async function readTemplateFolder(subFolder: string) {
   const templateFile = await readTemplateJson(path.join(subFolder, 'template.json'));
 
   const templateFields = await readTemplateFolderFieldFiles(subFolder);


### PR DESCRIPTION
- renamed 'file' option to 'template'
- you can pass either a template folder or a template file to 'template'