### PR TITLE
fix: EXHCLI-9 tokens for wrong consumer generated

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,6 +1,6 @@
-import axios from 'axios';
 import * as fs from 'fs/promises';
 import * as chalk from 'chalk';
+import { OAuth1Client } from '@extrahorizon/javascript-sdk';
 import { epilogue } from '../helpers/util';
 import { EXH_CONFIG_FILE_DIR, EXH_CONFIG_FILE } from '../constants';
 
@@ -33,8 +33,14 @@ export const builder = (yargs: any) => epilogue(yargs).options({
     describe: 'Consumer secret',
   },
 });
-export const handler = async ({ host, email, password, consumerKey, consumerSecret }) => {
-  const { data: response } = await axios.post(`${host}/auth/v2/oauth1/tokens`, { email, password });
+
+export const handler = async ({ sdk, host, email, password, consumerKey, consumerSecret }:
+  {sdk: OAuth1Client; host:string; email: string; password: string; consumerKey: string; consumerSecret: string;}) => {
+  // authenticate
+  const response = await sdk.auth.authenticate({
+    email,
+    password,
+  });
 
   /* Create directory if it doesn't exist yet */
   try {

--- a/src/exh.ts
+++ b/src/exh.ts
@@ -13,7 +13,17 @@ interface ExHCredentials {
 let initialized = false;
 let sdk = null;
 
-export default async function create() {
+export async function sdkInitOnly(apiHost: string, consumerKey: string, consumerSecret: string) {
+  if (initialized) return sdk;
+  sdk = createOAuth1Client({
+    consumerKey,
+    consumerSecret,
+    host: apiHost,
+  });
+  return sdk;
+}
+
+export async function sdkAuth() {
   if (initialized) return sdk;
   let credentials: any = {};
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import * as yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { UpdateNotifier } from 'update-notifier';
 import * as tty from 'tty';
-import ExH from './exh';
+import { sdkAuth, sdkInitOnly } from './exh';
 
 function checkForNewVersion() {
   const pkg = require('../package.json'); // eslint-disable-line @typescript-eslint/no-var-requires
@@ -25,9 +25,10 @@ yargs(hideBin(process.argv)).middleware(async argv => {
     isTTY = false;
   }
 
-  if (argv.email && argv.password) {
+  if (argv.host && argv.consumerKey && argv.consumerSecret) {
+    const sdk = await sdkInitOnly(argv.host as string, argv.consumerKey as string, argv.consumerSecret as string);
     /* Login command, don't authenticate with sdk */
-    return { isTTY };
+    return { sdk, isTTY };
   }
 
   /* Inject sdk authentication into every command */
@@ -35,7 +36,7 @@ yargs(hideBin(process.argv)).middleware(async argv => {
     return { sdk: 'no-sdk', isTTY };
   }
 
-  const sdk = await ExH();
+  const sdk = await sdkAuth();
   return { sdk, isTTY };
 }).commandDir('commands')
   .strict()


### PR DESCRIPTION
The login command generated tokens for the default consumer,
not the user-provided one.