### PR TITLE
EXHCLI-37 Fix setting of execution permission

### DIFF
--- a/src/commands/tasks/sync.ts
+++ b/src/commands/tasks/sync.ts
@@ -74,7 +74,6 @@ export const builder = (yargs: any) => epilogue(yargs).options({
   },
   executionPermission: {
     type: 'string',
-    default: 'permissionRequired',
   },
 })
   .check(async ({ path, entryPoint, runtime, name, code, executionPermission }) => {


### PR DESCRIPTION
The default setting of execution permission is causing it to be overridden every time a task config is used because it's passed along as a default parameter.