### PR TITLE
EXH-696 Add this version of the json schema for config files on creation

### DIFF
--- a/src/commands/data/schemas/init.ts
+++ b/src/commands/data/schemas/init.ts
@@ -1,6 +1,6 @@
 import { writeFile, mkdir } from 'fs/promises';
 import * as osPath from 'path';
-import { epilogue } from '../../../helpers/util';
+import { epilogue, getCliVersion } from '../../../helpers/util';
 
 export const command = 'init <name>';
 export const desc = 'Create a basic schema configuration file';
@@ -29,7 +29,7 @@ export const handler = async function init({ name, path }: { name: string; path:
 
 function createSchema(name: string) {
   return {
-    $schema: 'https://swagger.extrahorizon.com/cli/1.10.0/config-json-schemas/Schema.json',
+    $schema: `https://swagger.extrahorizon.com/cli/${getCliVersion()}/config-json-schemas/Schema.json`,
     name,
     description: `The ${name} schema`,
     createMode: 'allUsers',

--- a/src/commands/tasks/createrepo.ts
+++ b/src/commands/tasks/createrepo.ts
@@ -1,6 +1,6 @@
 import { readFile, writeFile } from 'fs/promises';
 import * as chalk from 'chalk';
-import { asyncExec, epilogue } from '../../helpers/util';
+import { asyncExec, epilogue, getCliVersion } from '../../helpers/util';
 
 export const command = 'create-repo <name>';
 export const desc = 'Create a new task repository';
@@ -32,6 +32,7 @@ async function changePackageFile(name: string) {
 
   try {
     const taskConfig = JSON.parse((await readFile(`${name}/task-config.json`)).toString());
+    taskConfig.$schema = `https://swagger.extrahorizon.com/cli/${getCliVersion()}/config-json-schemas/TaskConfig.json`;
     taskConfig.name = name;
     taskConfig.description = `${name} task`;
     await writeFile(`${name}/task-config.json`, JSON.stringify(taskConfig, null, 4));

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -1,5 +1,6 @@
 import { exec } from 'child_process';
 import * as fs from 'fs';
+import * as path from 'path';
 import * as chalk from 'chalk';
 import * as yargs from 'yargs';
 import { EXH_CONFIG_FILE } from '../constants';
@@ -67,4 +68,10 @@ export function loadAndAssertCredentials() {
     errorMessage += `Missing environment variables: ${missingEnvironmentVariables.join(',')}`;
     throw new Error(`Failed to retrieve all credentials. ${errorMessage}`);
   }
+}
+
+export function getCliVersion() {
+  const packageJsonPath = path.join(__dirname, '../../package.json');
+  const packageJsonString = fs.readFileSync(packageJsonPath, 'utf-8');
+  return JSON.parse(packageJsonString).version;
 }


### PR DESCRIPTION
There are no tests for the create repo command, doing so would also require some reworking if we want to do it properly. But, here is proof it does work, automatically added it to the task-config for the template task:
<img width="1522" height="448" alt="image" src="https://github.com/user-attachments/assets/ffd1249f-3571-4b6b-add0-4abd6f0eb0cb" />
