### PR TITLE
EXH-696 Correctly target json schema files for dev builds

### DIFF
--- a/src/commands/data/schemas/init.ts
+++ b/src/commands/data/schemas/init.ts
@@ -1,6 +1,6 @@
 import { writeFile, mkdir } from 'fs/promises';
 import * as osPath from 'path';
-import { epilogue, getCliVersion } from '../../../helpers/util';
+import { epilogue, getSwaggerDocumentationUrl } from '../../../helpers/util';
 
 export const command = 'init <name>';
 export const desc = 'Create a basic schema configuration file';
@@ -29,7 +29,7 @@ export const handler = async function init({ name, path }: { name: string; path:
 
 function createSchema(name: string) {
   return {
-    $schema: `https://swagger.extrahorizon.com/cli/${getCliVersion()}/config-json-schemas/Schema.json`,
+    $schema: getSwaggerDocumentationUrl('config-json-schemas/Schema.json'),
     name,
     description: `The ${name} schema`,
     createMode: 'allUsers',

--- a/src/commands/tasks/createrepo.ts
+++ b/src/commands/tasks/createrepo.ts
@@ -1,6 +1,6 @@
 import { readFile, writeFile } from 'fs/promises';
 import * as chalk from 'chalk';
-import { asyncExec, epilogue, getCliVersion } from '../../helpers/util';
+import { asyncExec, epilogue, getSwaggerDocumentationUrl } from '../../helpers/util';
 
 export const command = 'create-repo <name>';
 export const desc = 'Create a new task repository';
@@ -32,7 +32,7 @@ async function changePackageFile(name: string) {
 
   try {
     const taskConfig = JSON.parse((await readFile(`${name}/task-config.json`)).toString());
-    taskConfig.$schema = `https://swagger.extrahorizon.com/cli/${getCliVersion()}/config-json-schemas/TaskConfig.json`;
+    taskConfig.$schema = getSwaggerDocumentationUrl('config-json-schemas/TaskConfig.json');
     taskConfig.name = name;
     taskConfig.description = `${name} task`;
     await writeFile(`${name}/task-config.json`, JSON.stringify(taskConfig, null, 4));

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -70,10 +70,27 @@ export function loadAndAssertCredentials() {
   }
 }
 
-export function getCliVersion() {
+// Return a string like: https://swagger.extrahorizon.com/cli/${cliVersion}/${subPath}
+export function getSwaggerDocumentationUrl(subPath: string) {
   const packageJsonPath = path.join(__dirname, '../../package.json');
   const packageJsonString = fs.readFileSync(packageJsonPath, 'utf-8');
-  return JSON.parse(packageJsonString).version;
+
+  // Might be `1.10.0` or something like `1.10.0-dev-108-6b89c8f` or `1.10.0-feature-108-6b89c8f`
+  const packageVersion = JSON.parse(packageJsonString).version;
+
+  // If it is a stable version we want to return `1.10.0`
+  if (packageVersion.match(/^\d+\.\d+\.\d+$/)) {
+    return `https://swagger.extrahorizon.com/cli/${packageVersion}/${subPath}`;
+  }
+
+  // If it is not a stable version, we always return `${version}-dev`
+  // As determined by the "Publish the json-schemas of the configuration files" GitHub Action step
+  if (packageVersion.match(/^\d+\.\d+\.\d+-.*$/)) {
+    const versionParts = packageVersion.split('-');
+    return `https://swagger.extrahorizon.com/cli/${versionParts[0]}-dev/${subPath}`;
+  }
+
+  throw new Error(`Unknown CLI version format: ${packageVersion}`);
 }
 
 export function getAjvErrorStrings(errors: any[]) {


### PR DESCRIPTION
Aligning with the way to json schema files are actually published to the swagger.exh.com bucket