### PR TITLE
Improve feedback on usage of an unknown/incomplete command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### v1.13.6
 * Improved the reporting of errors from the API, including additional information when available
+* Improved the reporting of using unknown or incomplete commands, including usage information
 * Fixed some inconsistencies in the data schema validation, now better aligned with the backend
 * Fixed a bug in `exh data schemas sync` where permission mode arrays were not being correctly compared
 * Updated the ExH SDK to `8.13.0` to fix a security warning from `form-data` (vulnerable code was not in use)

--- a/gitbook/other/change-log.md
+++ b/gitbook/other/change-log.md
@@ -2,6 +2,8 @@
 
 ### v1.13.6
 * Improved the reporting of errors from the API, including additional information when available
+* Improved the reporting of using unknown or incomplete commands, including usage information
+* Fixed some inconsistencies in the data schema validation, now better aligned with the backend
 * Fixed a bug in `exh data schemas sync` where permission mode arrays were not being correctly compared
 * Updated the ExH SDK to `8.13.0` to fix a security warning from `form-data` (vulnerable code was not in use)
 

--- a/src/commands/data.ts
+++ b/src/commands/data.ts
@@ -2,5 +2,10 @@ import { epilogue } from '../helpers/util';
 
 export const command = 'data <command>';
 export const desc = 'Manage data';
-export const builder = (yargs: any) => epilogue(yargs).commandDir('data');
+
+export const builder = (yargs: any) => epilogue(yargs)
+  .commandDir('data')
+  .strict()
+  .demandCommand(1);
+
 export const handler = () => { /* empty */ };

--- a/src/commands/data/schemas.ts
+++ b/src/commands/data/schemas.ts
@@ -2,5 +2,10 @@ import { epilogue } from '../../helpers/util';
 
 export const command = 'schemas <command>';
 export const desc = 'Manage data schemas';
-export const builder = (yargs: any) => epilogue(yargs).commandDir('schemas');
+
+export const builder = (yargs: any) => epilogue(yargs)
+  .commandDir('schemas')
+  .strict()
+  .demandCommand(1);
+
 export const handler = () => { /* empty */ };

--- a/src/commands/dispatchers.ts
+++ b/src/commands/dispatchers.ts
@@ -3,5 +3,10 @@ import { epilogue } from '../helpers/util';
 
 export const command = 'dispatchers <command>';
 export const desc = 'Manage Dispatchers within Extra Horizon';
-export const builder = (yargs: Argv) => epilogue(yargs).commandDir('dispatchers');
+
+export const builder = (yargs: Argv) => epilogue(yargs)
+  .commandDir('dispatchers')
+  .strict()
+  .demandCommand(1);
+
 export const handler = () => { /* empty */ };

--- a/src/commands/localizations.ts
+++ b/src/commands/localizations.ts
@@ -2,6 +2,10 @@ import { epilogue } from '../helpers/util';
 
 export const command = 'localizations <command>';
 export const desc = 'Manage localizations';
-export const builder = (yargs: any) => epilogue(yargs).commandDir('localizations');
+
+export const builder = (yargs: any) => epilogue(yargs)
+  .commandDir('localizations')
+  .strict()
+  .demandCommand(1);
 
 export const handler = () => { /* empty */ };

--- a/src/commands/settings.ts
+++ b/src/commands/settings.ts
@@ -3,5 +3,10 @@ import { epilogue } from '../helpers/util';
 
 export const command = 'settings <command>';
 export const desc = 'Manage Service Settings within Extra Horizon';
-export const builder = (yargs: Argv) => epilogue(yargs).commandDir('settings');
+
+export const builder = (yargs: Argv) => epilogue(yargs)
+  .commandDir('settings')
+  .strict()
+  .demandCommand(1);
+
 export const handler = () => { /* empty */ };

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -2,6 +2,10 @@ import { epilogue } from '../helpers/util';
 
 export const command = 'tasks <command>';
 export const desc = 'Manage tasks';
-export const builder = (yargs: any) => epilogue(yargs).commandDir('tasks');
+
+export const builder = (yargs: any) => epilogue(yargs)
+  .commandDir('tasks')
+  .strict()
+  .demandCommand(1);
 
 export const handler = () => { /* empty */ };

--- a/src/commands/templates.ts
+++ b/src/commands/templates.ts
@@ -2,6 +2,10 @@ import { epilogue } from '../helpers/util';
 
 export const command = 'templates <command>';
 export const desc = 'Manage templates';
-export const builder = (yargs: any) => epilogue(yargs).commandDir('templates');
+
+export const builder = (yargs: any) => epilogue(yargs)
+  .commandDir('templates')
+  .strict()
+  .demandCommand(1);
 
 export const handler = () => { /* empty */ };


### PR DESCRIPTION
Same construct as in the main level of the commands.
Before `exh invalid` would fail but `exh dispatchers invalid` would not, it would simply exit successfully.
Now all unknown/partial commands fail and print usage